### PR TITLE
Hot fixes and updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ build/
 .idea/
 android/bin/
 example/.flutter-plugins-dependencies
+example/.flutter-plugins
 example/ios/Flutter/flutter_export_environment.sh
 /example/android/app/src/main/java/io/flutter/plugins/GeneratedPluginRegistrant.java
 /example/ios/Podfile.lock
+/example/ios/Flutter/Generated.xcconfig

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.0.2+1
+
+* Fix for sending properties to Klaviyo API, empty string in phone number caused an issue
+* Added missing properties: `organization`, `title`, `image` and `properties`
+
 ## 0.0.1+7
 
 * Updated Android SDK to 1.1.0, null checks

--- a/ios/Classes/KlaviyoFlutterPlugin.swift
+++ b/ios/Classes/KlaviyoFlutterPlugin.swift
@@ -78,7 +78,7 @@ public class KlaviyoFlutterPlugin: NSObject, FlutterPlugin, UNUserNotificationCe
                 address1: arguments["address1"] as? String,
                 address2: arguments["address2"] as? String,
                 latitude: (arguments["latitude"] as? String)?.toDouble,
-                longitude: (arguments["latitude"] as? String)?.toDouble,
+                longitude: (arguments["longitude"] as? String)?.toDouble,
                 region: arguments["region"] as? String)
             )
           klaviyo.set(profile: profile)

--- a/ios/Classes/KlaviyoFlutterPlugin.swift
+++ b/ios/Classes/KlaviyoFlutterPlugin.swift
@@ -68,18 +68,36 @@ public class KlaviyoFlutterPlugin: NSObject, FlutterPlugin, UNUserNotificationCe
 
         case METHOD_UPDATE_PROFILE:
           let arguments = call.arguments as! [String: Any]
+          // parsing location
+          let address1 = arguments["address1"] as? String
+          let address2 = arguments["address2"] as? String
+          let latitude = (arguments["latitude"] as? String)?.toDouble
+          let longitude = (arguments["longitude"] as? String)?.toDouble
+          let region = arguments["region"] as? String
+        
+          var location: Profile.Location?
+        
+          if(address1 != nil && address2 != nil && latitude != nil && longitude != nil && region != nil) {
+            location = Profile.Location(
+                address1: address1,
+                address2: address2,
+                latitude: latitude,
+                longitude: longitude,
+                region: region)
+          }
+        
+        
           let profile = Profile(
             email: arguments["email"] as? String,
             phoneNumber: arguments["phone_number"] as? String,
             externalId: arguments["external_id"] as? String,
             firstName: arguments["first_name"] as? String,
             lastName: arguments["last_name"] as? String,
-            location: Profile.Location(
-                address1: arguments["address1"] as? String,
-                address2: arguments["address2"] as? String,
-                latitude: (arguments["latitude"] as? String)?.toDouble,
-                longitude: (arguments["longitude"] as? String)?.toDouble,
-                region: arguments["region"] as? String)
+            organization: arguments["organization"] as? String,
+            title: arguments["title"] as? String,
+            image: arguments["image"] as? String,
+            location: location,
+            properties: arguments["properties"] as? [String:Any]
             )
           klaviyo.set(profile: profile)
           result("Profile updated")

--- a/ios/klaviyo_flutter.podspec
+++ b/ios/klaviyo_flutter.podspec
@@ -14,7 +14,7 @@ A new flutter plugin project.
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'KlaviyoSwift'
+  s.dependency 'KlaviyoSwift', '~> 2.0.1'
   s.ios.deployment_target = '13.0'
   s.swift_version = '5.0'
 end

--- a/lib/klaviyo_flutter.dart
+++ b/lib/klaviyo_flutter.dart
@@ -3,10 +3,10 @@ library klaviyo_flutter;
 import 'dart:async';
 
 import 'package:klaviyo_flutter/src/klaviyo_flutter_platform_interface.dart';
-import 'package:klaviyo_flutter/src/klaviyo_profile_model.dart';
+import 'package:klaviyo_flutter/src/klaviyo_profile.dart';
 
 export 'klaviyo_flutter.dart';
-export 'src/klaviyo_profile_model.dart';
+export 'src/klaviyo_profile.dart';
 
 class Klaviyo {
   /// private constructor to not allow the object creation from outside.
@@ -57,7 +57,7 @@ class Klaviyo {
   /// @return Returns Future<String> success when called on Android or iOS
   ///
   /// All profile attributes recognised by the Klaviyo APIs [com.klaviyo.analytics.model.ProfileKey]
-  Future<String> updateProfile(KlaviyoProfileModel profileModel) async {
+  Future<String> updateProfile(KlaviyoProfile profileModel) async {
     return KlaviyoFlutterPlatform.instance.updateProfile(profileModel);
   }
 

--- a/lib/src/klaviyo_flutter_platform_interface.dart
+++ b/lib/src/klaviyo_flutter_platform_interface.dart
@@ -1,4 +1,4 @@
-import 'package:klaviyo_flutter/src/klaviyo_profile_model.dart';
+import 'package:klaviyo_flutter/src/klaviyo_profile.dart';
 import 'package:klaviyo_flutter/src/method_channel_klaviyo_flutter.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
@@ -79,7 +79,7 @@ abstract class KlaviyoFlutterPlatform extends PlatformInterface {
   //     object REGION : ProfileKey("region")
   //     object ZIP : ProfileKey("zip")
   //     object TIMEZONE : ProfileKey("timezone")
-  Future<String> updateProfile(KlaviyoProfileModel profileModel) async {
+  Future<String> updateProfile(KlaviyoProfile profileModel) async {
     throw UnimplementedError('updateProfile() has not been implemented.');
   }
 

--- a/lib/src/klaviyo_profile.dart
+++ b/lib/src/klaviyo_profile.dart
@@ -1,6 +1,6 @@
 import 'package:equatable/equatable.dart';
 
-class KlaviyoProfileModel extends Equatable {
+class KlaviyoProfile extends Equatable {
   final String? id;
   final String? email;
   final String? phoneNumber;
@@ -12,7 +12,7 @@ class KlaviyoProfileModel extends Equatable {
   final String? latitude;
   final String? longitude;
 
-  const KlaviyoProfileModel({
+  const KlaviyoProfile({
     this.id,
     this.email,
     this.phoneNumber,

--- a/lib/src/klaviyo_profile.dart
+++ b/lib/src/klaviyo_profile.dart
@@ -6,11 +6,15 @@ class KlaviyoProfile extends Equatable {
   final String? phoneNumber;
   final String? firstName;
   final String? lastName;
+  final String? organization;
+  final String? title;
+  final String? image;
   final String? address1;
   final String? address2;
   final String? region;
   final String? latitude;
   final String? longitude;
+  final Map<String, dynamic>? properties;
 
   const KlaviyoProfile({
     this.id,
@@ -18,20 +22,43 @@ class KlaviyoProfile extends Equatable {
     this.phoneNumber,
     this.firstName,
     this.lastName,
+    this.organization,
+    this.title,
+    this.image,
     this.address1,
     this.address2,
     this.region,
     this.latitude,
     this.longitude,
+    this.properties,
   });
 
   @override
-  List<Object?> get props =>
-      [id, email, phoneNumber, lastName, address1, region, latitude, longitude];
+  List<Object?> get props => [
+        id,
+        email,
+        phoneNumber,
+        firstName,
+        lastName,
+        organization,
+        title,
+        image,
+        address1,
+        address2,
+        region,
+        latitude,
+        longitude,
+        properties,
+      ];
 
   @override
-  String toString() =>
-      'ProfileModel(id: $id, email: $email, phoneNumber: $phoneNumber, lastName: $lastName, address1: $address1, region: $region, latitude: $latitude, longitude: $longitude)';
+  String toString() {
+    var properties = toJson().toString();
+
+    var propsWithoutBrackets = properties.substring(1, properties.length - 1);
+
+    return 'KlaviyoProfile($propsWithoutBrackets)';
+  }
 
   Map<String, dynamic> toJson() => {
         'external_id': id,
@@ -39,10 +66,14 @@ class KlaviyoProfile extends Equatable {
         'phone_number': phoneNumber,
         'first_name': firstName,
         'last_name': lastName,
+        'organization': organization,
+        'title': title,
+        'image': image,
         'address1': address1,
         'address2': address2,
         'region': region,
         'latitude': latitude,
         'longitude': longitude,
+        'properties': properties,
       };
 }

--- a/lib/src/klaviyo_profile_model.dart
+++ b/lib/src/klaviyo_profile_model.dart
@@ -1,8 +1,8 @@
 import 'package:equatable/equatable.dart';
 
 class KlaviyoProfileModel extends Equatable {
-  final String id;
-  final String email;
+  final String? id;
+  final String? email;
   final String? phoneNumber;
   final String? firstName;
   final String? lastName;
@@ -13,8 +13,8 @@ class KlaviyoProfileModel extends Equatable {
   final String? longitude;
 
   const KlaviyoProfileModel({
-    required this.id,
-    required this.email,
+    this.id,
+    this.email,
     this.phoneNumber,
     this.firstName,
     this.lastName,
@@ -36,13 +36,13 @@ class KlaviyoProfileModel extends Equatable {
   Map<String, dynamic> toJson() => {
         'external_id': id,
         'email': email,
-        'phone_number': phoneNumber ?? '',
-        'first_name': firstName ?? '',
-        'last_name': lastName ?? '',
-        'address1': address1 ?? '',
-        'address2': address2 ?? '',
-        'region': region ?? '',
-        'latitude': latitude ?? '',
-        'longitude': longitude ?? '',
+        'phone_number': phoneNumber,
+        'first_name': firstName,
+        'last_name': lastName,
+        'address1': address1,
+        'address2': address2,
+        'region': region,
+        'latitude': latitude,
+        'longitude': longitude,
       };
 }

--- a/lib/src/method_channel_klaviyo_flutter.dart
+++ b/lib/src/method_channel_klaviyo_flutter.dart
@@ -3,7 +3,7 @@ import 'dart:developer';
 import 'package:flutter/services.dart';
 
 import 'klaviyo_flutter_platform_interface.dart';
-import 'klaviyo_profile_model.dart';
+import 'klaviyo_profile.dart';
 
 const MethodChannel _channel = MethodChannel('com.rightbite.denisr/klaviyo');
 
@@ -18,7 +18,7 @@ class MethodChannelKlaviyoFlutter extends KlaviyoFlutterPlatform {
 
   /// Assign new identifiers and attributes to the currently tracked profile once.
   @override
-  Future<String> updateProfile(KlaviyoProfileModel profileModel) async {
+  Future<String> updateProfile(KlaviyoProfile profileModel) async {
     final resultMap = await _channel.invokeMethod<String>(
       'updateProfile',
       profileModel.toJson(),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: klaviyo_flutter
 description: Flutter plugin for Klaviyo integration. Provides push messaging
   and Klaviyo analitics services
-version: 0.0.1+7
+version: 0.0.2+1
 homepage: https://github.com/drybnikov/klaviyo_flutter
 
 environment:

--- a/test/klaviyo_flutter_test.dart
+++ b/test/klaviyo_flutter_test.dart
@@ -23,7 +23,7 @@ void main() {
 
     test('updateUser', () {
       Klaviyo.instance.updateProfile(
-        KlaviyoProfileModel(
+        KlaviyoProfile(
           id: '1',
           email: 'test@example.com',
           phoneNumber: '+37256123456',

--- a/test/klaviyo_flutter_test.dart
+++ b/test/klaviyo_flutter_test.dart
@@ -29,24 +29,40 @@ void main() {
           phoneNumber: '+37256123456',
           firstName: 'John Doe',
           lastName: 'Doe',
+          organization: 'Organization',
+          title: 'title',
+          image: 'http://someurl.com/image.png',
           address1: 'Some street 1',
+          address2: 'Some steet 2',
           region: 'Tallinn',
           latitude: '59.436962',
           longitude: '24.753574',
+          properties: {
+            'app_version': 321,
+          },
         ),
       );
-      expectMethodCall('updateProfile', arguments: {
-        'external_id': '1',
-        'email': 'test@example.com',
-        'phone_number': '+37256123456',
-        'first_name': 'John Doe',
-        'last_name': 'Doe',
-        'address1': 'Some street 1',
-        'address2': '',
-        'region': 'Tallinn',
-        'latitude': '59.436962',
-        'longitude': '24.753574',
-      });
+      expectMethodCall(
+        'updateProfile',
+        arguments: {
+          'external_id': '1',
+          'email': 'test@example.com',
+          'phone_number': '+37256123456',
+          'first_name': 'John Doe',
+          'last_name': 'Doe',
+          'organization': 'Organization',
+          'title': 'title',
+          'image': 'http://someurl.com/image.png',
+          'address1': 'Some street 1',
+          'address2': 'Some steet 2',
+          'region': 'Tallinn',
+          'latitude': '59.436962',
+          'longitude': '24.753574',
+          'properties': {
+            'app_version': 321,
+          }
+        },
+      );
     });
 
     test('resetProfile', () {


### PR DESCRIPTION
Empty string in phone number caused an issue and rest of properties was ignored while updating of profile.

Fixed wrong key for longitude on iOS side. 

Removed redundant post-fix 'model' for KlaviyoProfile.

Added missing fields, such as `organization`, `title`, `image` and `properties` for custom purposes.