### PR TITLE
fix: Use correct Klaviyo notification key

### DIFF
--- a/android/src/main/kotlin/com/rightbite/denisr/KlaviyoFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/rightbite/denisr/KlaviyoFlutterPlugin.kt
@@ -177,7 +177,7 @@ class KlaviyoFlutterPlugin : MethodCallHandler, FlutterPlugin {
         }
     }
 
-    private fun isKlaviyoPush(payload: Map<String, String>) = payload.containsKey("com.klaviyo._k")
+    private fun isKlaviyoPush(payload: Map<String, String>) = payload.containsKey("_k")
 
     companion object {
         private const val CHANNEL_NAME = "com.rightbite.denisr/klaviyo"


### PR DESCRIPTION
It was checking on the incorrect key to determine a Klaviyo push.

It was checking for the [Intent](https://github.com/klaviyo/klaviyo-android-sdk/blob/c842528496a889c5488c20185334ffba55c8459c/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt#L357) instead of the [push](https://github.com/klaviyo/klaviyo-android-sdk/blob/c842528496a889c5488c20185334ffba55c8459c/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoRemoteMessage.kt#L80)