### PR TITLE
Adding support for SDK naming + versioning

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,14 +2,14 @@ group 'com.rightbite.denisr'
 version '0.1.0'
 
 buildscript {
-    ext.kotlin_version = '1.8.0'
+    ext.kotlin_version = '1.9.0'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.3'
+        classpath 'com.android.tools.build:gradle:8.0.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -27,6 +27,16 @@ apply plugin: 'kotlin-android'
 
 android {
     compileSdk 34
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
+    }
+    kotlinOptions {
+        jvmTarget = '17'
+    }
+
+    namespace 'com.rightbite.denisr'
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.rightbite.denisr">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application>
         <service

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -1,0 +1,4 @@
+<resources>
+    <string name="klaviyo_sdk_version_override">0.1.1</string>
+    <string name="klaviyo_sdk_name_override">flutter_community</string>
+</resources>

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -1,3 +1,8 @@
+plugins {
+    id 'com.android.application'
+    id 'kotlin-android'
+}
+
 def localProperties = new Properties()
 def localPropertiesFile = rootProject.file('local.properties')
 if (localPropertiesFile.exists()) {
@@ -21,12 +26,20 @@ if (flutterVersionName == null) {
     flutterVersionName = '1.0'
 }
 
-apply plugin: 'com.android.application'
-apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion 34
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
+    }
+    kotlinOptions {
+        jvmTarget = '17'
+    }
+
+    namespace 'com.rightbite.denisr.klaviyoexample'
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,12 +1,12 @@
 buildscript {
-    ext.kotlin_version = '1.7.20'
+    ext.kotlin_version = '1.9.0'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.3.1'
+        classpath 'com.android.tools.build:gradle:8.0.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Thu Jun 17 14:27:11 IST 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-all.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
# PLEASE DO NOT MERGE THIS YET - IT WILL BREAK PUSH NOTIFICATIONS ON ANDROID FOR SDK USERS

Main addition here is `android/src/main/res/values/strings.xml`, which allows Klaviyo companies to see that their users are using the Flutter SDK (rather than native iOS and Android)

![image](https://github.com/user-attachments/assets/d3d6deb1-070f-4a36-a9d1-9f5851b43788)

I also added some changes that allowed me to run this on my android device. Feel free to remove these if you don't want changes there, but when I tried to run the example app on Android I was unable to before these. 

### todo
- I need to add the iOS configuration file to support this
- Internally, we need to add support for the `flutter_community` enum for push notifications to function. This is a simple addition, and I'll likely get to this next week. 

Thanks again for allowing me to contribute, and for writing this SDK in the first place!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new string resources for Klaviyo SDK version and name configuration.
- **Improvements**
	- Updated Kotlin version to 1.9.0 and Android Gradle plugin to 8.0.0 for enhanced performance and features.
	- Updated compile options to support Java 17 compatibility.
	- Updated compile SDK version to 34.
- **Bug Fixes**
	- Removed outdated package declaration from the AndroidManifest.xml for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->