### PR TITLE
Add namespace to build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -26,6 +26,9 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    if (project.android.hasProperty("namespace")) {
+        namespace 'com.rightbite.denisr'
+    }
     compileSdk 34
 
     sourceSets {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -26,6 +26,8 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    // Namespace declaration for Android Gradle Plugin compatibility
+    // Matches the group ID and existing package structure
     if (project.android.hasProperty("namespace")) {
         namespace 'com.rightbite.denisr'
     }


### PR DESCRIPTION
Adds the namespace to build.gradle to support newer android gradle plugin versions. 
Resolves #17 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Chores**
	- Introduced a conditional declaration for the namespace property in the Android build configuration, allowing for dynamic project configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->